### PR TITLE
Fix label overlap

### DIFF
--- a/auth-method-basic.js
+++ b/auth-method-basic.js
@@ -50,7 +50,9 @@ class AuthMethodBasic extends AuthMethodBase {
 
       anypoint-input,
       anypoint-masked-input {
-        display: block;
+        display: inline-block;
+        width: calc(100% - 16px);
+        margin: 8px;
       }`
     ];
   }

--- a/auth-method-digest.js
+++ b/auth-method-digest.js
@@ -80,7 +80,9 @@ class AuthMethodDigest extends AuthMethodBase {
 
       anypoint-input,
       anypoint-masked-input {
-        display: block;
+        display: inline-block;
+        width: calc(100% - 16px);
+        margin: 8px;
       }`
     ];
   }

--- a/auth-method-ntlm.js
+++ b/auth-method-ntlm.js
@@ -49,7 +49,9 @@ class AuthMethodNtlm extends AuthMethodBase {
 
       anypoint-input,
       anypoint-masked-input {
-        display: block;
+        display: inline-block;
+        width: calc(100% - 16px);
+        margin: 8px;
       }`
     ];
   }


### PR DESCRIPTION
Fixed overlap of invalid message in auth method basic, ntlm, & digest using strategy seen in 
https://github.com/advanced-rest-client/auth-methods/blob/b175fec384022b5073af4474cc0c4d14420e2a0d/auth-method-oauth1.js#L100


<img width="628" alt="Screen Shot 2019-11-12 at 9 54 25 AM" src="https://user-images.githubusercontent.com/5685783/68673813-5671f000-0533-11ea-9efe-a7c808fd0e16.png">
<img width="500" alt="Screen Shot 2019-11-12 at 9 42 12 AM" src="https://user-images.githubusercontent.com/5685783/68673815-5671f000-0533-11ea-8841-94562f27cf1b.png">
