### PR TITLE
fix: apic-432 show client id and secret fields when client credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ $RECYCLE.BIN/
 
 node_modules
 coverage
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: node_js
 node_js: stable
-sudo: required
 addons:
-  apt:
-    sources:
-    - google-chrome
-    packages:
-    - google-chrome-stable
+  chrome: stable
 script:
-- npm test
-- if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test:sl; fi
+  - npm test
+  - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then npm run test:sl; fi
 env:
   global:
     - secure: >-

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/advanced-rest-client/auth-methods.svg?branch=stage)](https://travis-ci.org/advanced-rest-client/auth-methods)
 
 # auth-methods
+**This project is deprecated.** Please use [authorization-method](https://github.com/advanced-rest-client/authorization-method) instead.
 
 A set of elements that contains an UI to create different authorization headers like Basic, OAuth etc
 

--- a/auth-method-oauth2.js
+++ b/auth-method-oauth2.js
@@ -1854,8 +1854,7 @@ class AuthMethodOauth2 extends AmfHelperMixin(AuthMethodBase) {
     } = this;
 
     const customGrantRequired = !isCustomGrant;
-    const clientIdRequired = ['password'].indexOf(grantType) !== -1 ? false : customGrantRequired;
-    const showClientFields = clientIdRequired && grantType === 'client_credentials';
+    const clientIdRequired = ['client_credentials', 'password'].indexOf(grantType) !== -1 ? false : customGrantRequired;
     const secretDisabled = disabled ||
       this._isFieldDisabled(isCustomGrant, grantType, 'client_credentials', 'authorization_code');
     const hasAccessToken = !!accessToken;
@@ -1872,8 +1871,8 @@ class AuthMethodOauth2 extends AmfHelperMixin(AuthMethodBase) {
               @input="${this._valueHandler}"
               autocomplete="on"
               data-persistent="true"
-              ?hiddable="${!showClientFields}"
-              data-visible="implicit authorization_code"
+              hiddable
+              data-visible="implicit authorization_code client_credentials"
               .outlined="${outlined}"
               .compatibility="${compatibility}"
               .readOnly="${readOnly}"
@@ -1890,9 +1889,9 @@ class AuthMethodOauth2 extends AmfHelperMixin(AuthMethodBase) {
               .value="${clientSecret}"
               @input="${this._valueHandler}"
               autocomplete="on"
-              ?hiddable="${!showClientFields}"
+              hiddable
               data-persistent="true"
-              data-visible="authorization_code"
+              data-visible="authorization_code client_credentials"
               .outlined="${outlined}"
               .compatibility="${compatibility}"
               .readOnly="${readOnly}"

--- a/auth-method-oauth2.js
+++ b/auth-method-oauth2.js
@@ -1854,7 +1854,8 @@ class AuthMethodOauth2 extends AmfHelperMixin(AuthMethodBase) {
     } = this;
 
     const customGrantRequired = !isCustomGrant;
-    const clientIdRequired = ['client_credentials', 'password'].indexOf(grantType) !== -1 ? false : customGrantRequired;
+    const clientIdRequired = ['password'].indexOf(grantType) !== -1 ? false : customGrantRequired;
+    const showClientFields = clientIdRequired && grantType === 'client_credentials';
     const secretDisabled = disabled ||
       this._isFieldDisabled(isCustomGrant, grantType, 'client_credentials', 'authorization_code');
     const hasAccessToken = !!accessToken;
@@ -1871,7 +1872,7 @@ class AuthMethodOauth2 extends AmfHelperMixin(AuthMethodBase) {
               @input="${this._valueHandler}"
               autocomplete="on"
               data-persistent="true"
-              hiddable
+              ?hiddable="${!showClientFields}"
               data-visible="implicit authorization_code"
               .outlined="${outlined}"
               .compatibility="${compatibility}"
@@ -1889,7 +1890,7 @@ class AuthMethodOauth2 extends AmfHelperMixin(AuthMethodBase) {
               .value="${clientSecret}"
               @input="${this._valueHandler}"
               autocomplete="on"
-              hiddable
+              ?hiddable="${!showClientFields}"
               data-persistent="true"
               data-visible="authorization_code"
               .outlined="${outlined}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@advanced-rest-client/auth-methods",
-  "version": "5.0.10",
+  "version": "5.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@advanced-rest-client/auth-methods",
   "description": "A set of elements that contains an UI to create different authorization headers like Basic, OAuth etc",
-  "version": "5.0.10",
+  "version": "5.0.11",
   "license": "Apache-2.0",
   "main": "auth-methods.js",
   "keywords": [

--- a/test/auth-method-oauth2.client-credentials.test.js
+++ b/test/auth-method-oauth2.client-credentials.test.js
@@ -90,12 +90,12 @@ describe('<auth-method-oauth2>', function() {
 
       it('Client id is required', () => {
         const node = element.shadowRoot.querySelector('[name="clientId"]');
-        assert.isTrue(node.required);
+        assert.notEqual(node.required, true);
       });
 
       it('Client secret is required', () => {
         const node = element.shadowRoot.querySelector('[name="clientSecret"]');
-        assert.isTrue(node.required);
+        assert.notEqual(node.required, true);
       });
 
       it('Client secret is not disabled', () => {

--- a/test/auth-method-oauth2.client-credentials.test.js
+++ b/test/auth-method-oauth2.client-credentials.test.js
@@ -88,12 +88,12 @@ describe('<auth-method-oauth2>', function() {
         await aTimeout();
       });
 
-      it('Client id is required', () => {
+      it('Client id is not required', () => {
         const node = element.shadowRoot.querySelector('[name="clientId"]');
         assert.notEqual(node.required, true);
       });
 
-      it('Client secret is required', () => {
+      it('Client secret is not required', () => {
         const node = element.shadowRoot.querySelector('[name="clientSecret"]');
         assert.notEqual(node.required, true);
       });

--- a/test/auth-method-oauth2.client-credentials.test.js
+++ b/test/auth-method-oauth2.client-credentials.test.js
@@ -6,6 +6,7 @@ import '../auth-method-oauth2.js';
 
 describe('<auth-method-oauth2>', function() {
   const clientId = '821776164331-rserncqpdsq32lmbf5cfeolgcoujb6fm.apps.googleusercontent.com';
+  const clientSecret = 'test-secret';
   const accessTokenUri = 'https://accounts.google.com/o/oauth2/v2/auth';
   const scopes = ['email', 'profile'];
 
@@ -17,6 +18,7 @@ describe('<auth-method-oauth2>', function() {
     return (await fixture(html`<auth-method-oauth2
       granttype="client_credentials"
       clientid="${clientId}"
+      clientSecret="${clientSecret}"
       .accessTokenUri="${accessTokenUri}"
       .scopes="${scopes}"></auth-method-oauth2>`));
   }
@@ -86,14 +88,14 @@ describe('<auth-method-oauth2>', function() {
         await aTimeout();
       });
 
-      it('Client id is not required', () => {
+      it('Client id is required', () => {
         const node = element.shadowRoot.querySelector('[name="clientId"]');
-        assert.notEqual(node.required, true);
+        assert.isTrue(node.required);
       });
 
-      it('Client secret is not required', () => {
+      it('Client secret is required', () => {
         const node = element.shadowRoot.querySelector('[name="clientSecret"]');
-        assert.notEqual(node.required, true);
+        assert.isTrue(node.required);
       });
 
       it('Client secret is not disabled', () => {
@@ -101,10 +103,10 @@ describe('<auth-method-oauth2>', function() {
         assert.isFalse(node.disabled);
       });
 
-      it('Client secret is hidden', () => {
+      it('Client secret is visible', () => {
         const node = element.shadowRoot.querySelector('[name="clientSecret"]');
         const display = getComputedStyle(node).display;
-        assert.equal(display, 'none');
+        assert.equal(display, 'inline-block');
       });
 
       it('Advanced settings checkbox is not rendered', () => {


### PR DESCRIPTION
bug: Missing client Id and client secret for when authorizationGrants is client_credentials

